### PR TITLE
Log and unlog sequentially to avoid data corruption (fixes #26)

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -75,6 +75,18 @@ test('immigration', t => {
         })
     })
 
+    t.test('log', t => {
+      t.plan(1)
+
+      return migrate.log({}, 'done')
+        .then(() => migrate.migrate('up', {
+          new: true
+        }))
+        .then(() => {
+          return stat(SUCCESS_FILE).catch(() => t.pass('file is still removed'))
+        })
+    })
+
     t.test('cleanup', t => {
       return unlink(join(DIRECTORY, '.migrate.json'))
     })


### PR DESCRIPTION
This PR replaces the use of `Promise.all` with `Array.reduce` to run `log`, `unlog` and `tidy` sequentially for multiple files to avoid data corruption.